### PR TITLE
Ability to use the enum with an associated value

### DIFF
--- a/Sources/SwiftErrorHandler/Generic/Matchers/ErrorMatcher.swift
+++ b/Sources/SwiftErrorHandler/Generic/Matchers/ErrorMatcher.swift
@@ -23,6 +23,10 @@ public struct ErrorMatcher {
 
 public extension ErrorMatcher {
 
+    static func typeWithAnyAssociatedValue(_ error: Error) -> ErrorMatcher {
+        return .init(matcher: { ($0 as NSError).isEqual(error as NSError) })
+    }
+
     static func type(_ error: Error) -> ErrorMatcher {
         return .init(matcher: { $0.reflectedString == error.reflectedString })
     }


### PR DESCRIPTION
Purpose: handle enum with an associated value.

For example, error enum:
```
enum SomeError: Error {
 case fatalError(String)
}
```
Handler:
```
let errorHandler = ErrorHandler()
        .on(error: . typeWithAnyAssociatedValue(SomeError.fatalError("")), then: onError)
        .always(onAlways)
        .onNoMatch(onNoMatch)
```